### PR TITLE
fix upload and download

### DIFF
--- a/download/main.go
+++ b/download/main.go
@@ -6,47 +6,62 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"strings"
+
+	"gocloud.dev/blob/fileblob"
 
 	"github.com/tennix/tidb-cloud-backup/pkg"
 	"gocloud.dev/blob"
-	"gocloud.dev/blob/fileblob"
 )
 
 var (
-	cloud    string
-	bucket   string
-	endpoint string
-	srcDir   string
-	destDir  string
+	cloud         string
+	region        string
+	bucket        string
+	endpoint      string
+	srcDir        string
+	destDir       string
+	keepAttrsFile bool
 )
 
 func init() {
 	flag.StringVar(&cloud, "cloud", "", "Cloud storage to use")
+	flag.StringVar(&region, "region", "", "The region to send requests to.")
 	flag.StringVar(&bucket, "bucket", "tidb-backup", "Name of bucket")
 	flag.StringVar(&endpoint, "endpoint", "", "Endpoint of Ceph object store")
 	flag.StringVar(&srcDir, "srcDir", "", "Source data directory in bucket")
 	flag.StringVar(&destDir, "destDir", "", "Destination directory on local")
+	flag.BoolVar(&keepAttrsFile, "keepAttrsFile", false, "Generate attrs file when downloading files")
 	flag.Parse()
 }
 
 func main() {
 	ctx := context.Background()
-	b, err := pkg.SetupBucket(context.Background(), cloud, bucket, endpoint)
+	b, err := pkg.SetupBucket(context.Background(), cloud, region, bucket, endpoint)
 	if err != nil {
 		log.Fatalf("Failed to setup bucket: %s", err)
 	}
-	err = download(ctx, b, srcDir, destDir)
+	err = download(ctx, b, srcDir, destDir, keepAttrsFile)
 	if err != nil {
 		log.Fatalf("Failed to download data from bucket: %s/%s to %s, error: %s", bucket, srcDir, destDir, err)
 	}
 }
 
-func download(ctx context.Context, b *blob.Bucket, srcDir, destDir string) error {
-	localBucket, err := fileblob.OpenBucket(destDir, nil)
-	if err != nil {
-		log.Fatal(err)
+func download(ctx context.Context, b *blob.Bucket, srcDir, destDir string, keepAttrsFile bool) error {
+	var localBucket *blob.Bucket
+	var err error
+	if keepAttrsFile {
+		localBucket, err = fileblob.OpenBucket(destDir, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		localBucket, err = pkg.OpenBucket(destDir, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
-	iter := b.List(&blob.ListOptions{Prefix: srcDir})
+	iter := b.List(&blob.ListOptions{Prefix: strings.TrimPrefix(srcDir, "/")})
 	for {
 		obj, err := iter.Next(ctx)
 		if err == io.EOF {

--- a/pkg/fileblob.go
+++ b/pkg/fileblob.go
@@ -1,0 +1,201 @@
+package pkg
+
+import (
+	"context"
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"gocloud.dev/blob"
+	"gocloud.dev/blob/driver"
+	"gocloud.dev/gcerrors"
+)
+
+// Options sets options for constructing a *blob.Bucket backed by fileblob.
+type Options struct{}
+
+type bucket struct {
+	dir string
+}
+
+// openBucket creates a driver.Bucket that reads and writes to dir.
+// dir must exist.
+func openBucket(dir string, _ *Options) (driver.Bucket, error) {
+	dir = filepath.Clean(dir)
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", dir)
+	}
+	return &bucket{dir}, nil
+}
+
+// OpenBucket creates a *blob.Bucket backed by the filesystem and rooted at
+// dir, which must exist. See the package documentation for an example.
+func OpenBucket(dir string, opts *Options) (*blob.Bucket, error) {
+	drv, err := openBucket(dir, opts)
+	if err != nil {
+		return nil, err
+	}
+	return blob.NewBucket(drv), nil
+}
+
+var errNotImplemented = errors.New("not implemented")
+
+func (b *bucket) ErrorCode(err error) gcerrors.ErrorCode {
+	switch {
+	case os.IsNotExist(err):
+		return gcerrors.NotFound
+	case err == errNotImplemented:
+		return gcerrors.Unimplemented
+	default:
+		return gcerrors.Unknown
+	}
+}
+
+// path returns the full path for a key
+func (b *bucket) path(key string) string {
+	path := filepath.Join(b.dir, key)
+	return path
+}
+
+// ListPaged implements driver.ListPaged.
+func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driver.ListPage, error) {
+	return nil, nil
+}
+
+// As implements driver.As.
+func (b *bucket) As(i interface{}) bool { return false }
+
+// As implements driver.ErrorAs.
+func (b *bucket) ErrorAs(err error, i interface{}) bool {
+	if perr, ok := err.(*os.PathError); ok {
+		if p, ok := i.(**os.PathError); ok {
+			*p = perr
+			return true
+		}
+	}
+	return false
+}
+
+// Attributes implements driver.Attributes.
+func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes, error) {
+	return driver.Attributes{}, nil
+}
+
+// NewRangeReader implements driver.NewRangeReader.
+func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length int64, opts *driver.ReaderOptions) (driver.Reader, error) {
+	return &reader{}, nil
+}
+
+type reader struct {
+	r     io.Reader
+	c     io.Closer
+	attrs driver.ReaderAttributes
+}
+
+func (r *reader) Read(p []byte) (int, error) {
+	if r.r == nil {
+		return 0, io.EOF
+	}
+	return r.r.Read(p)
+}
+
+func (r *reader) Close() error {
+	if r.c == nil {
+		return nil
+	}
+	return r.c.Close()
+}
+
+func (r *reader) Attributes() driver.ReaderAttributes {
+	return r.attrs
+}
+
+func (r *reader) As(i interface{}) bool { return false }
+
+// NewTypedWriter implements driver.NewTypedWriter.
+func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType string, opts *driver.WriterOptions) (driver.Writer, error) {
+	path := b.path(key)
+	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+		return nil, err
+	}
+	f, err := ioutil.TempFile(filepath.Dir(path), "fileblob")
+	if err != nil {
+		return nil, err
+	}
+	if opts.BeforeWrite != nil {
+		if err := opts.BeforeWrite(func(interface{}) bool { return false }); err != nil {
+			return nil, err
+		}
+	}
+	w := &writer{
+		ctx:        ctx,
+		f:          f,
+		path:       path,
+		contentMD5: opts.ContentMD5,
+		md5hash:    md5.New(),
+	}
+	return w, nil
+}
+
+type writer struct {
+	ctx        context.Context
+	f          *os.File
+	path       string
+	contentMD5 []byte
+	// We compute the MD5 hash so that we can store it with the file attributes,
+	// not for verification.
+	md5hash hash.Hash
+}
+
+func (w *writer) Write(p []byte) (n int, err error) {
+	if _, err := w.md5hash.Write(p); err != nil {
+		return 0, err
+	}
+	return w.f.Write(p)
+}
+
+func (w *writer) Close() error {
+	err := w.f.Close()
+	if err != nil {
+		return err
+	}
+	// Always delete the temp file. On success, it will have been renamed so
+	// the Remove will fail.
+	defer func() {
+		_ = os.Remove(w.f.Name())
+	}()
+
+	// Check if the write was cancelled.
+	if err := w.ctx.Err(); err != nil {
+		return err
+	}
+
+	// Rename the temp file to path.
+	if err := os.Rename(w.f.Name(), w.path); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete implements driver.Delete.
+func (b *bucket) Delete(ctx context.Context, key string) error {
+	path := b.path(key)
+	err := os.Remove(path)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedURLOptions) (string, error) {
+	return "", errNotImplemented
+}

--- a/upload/main.go
+++ b/upload/main.go
@@ -3,16 +3,19 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/tennix/tidb-cloud-backup/pkg"
 )
 
 var (
 	cloud     string
+	region    string
 	bucket    string
 	endpoint  string
 	backupDir string
@@ -20,6 +23,7 @@ var (
 
 func init() {
 	flag.StringVar(&cloud, "cloud", "", "Cloud storage to use")
+	flag.StringVar(&region, "region", "", "The region to send requests to.")
 	flag.StringVar(&bucket, "bucket", "tidb-backup", "Name of bucket")
 	flag.StringVar(&endpoint, "endpoint", "", "Endpoint of Ceph object store")
 	flag.StringVar(&backupDir, "backup-dir", "", "Backup directory")
@@ -28,12 +32,12 @@ func init() {
 
 func main() {
 	ctx := context.Background()
-	b, err := pkg.SetupBucket(context.Background(), cloud, bucket, endpoint)
+	b, err := pkg.SetupBucket(context.Background(), region, cloud, bucket, endpoint)
 	if err != nil {
 		log.Fatalf("Failed to setup bucket: %s", err)
 	}
 
-	base := filepath.Base(backupDir)
+	prefixDir := fmt.Sprintf("%s/", filepath.Dir(backupDir))
 	err = filepath.Walk(backupDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -45,7 +49,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to read file: %s", err)
 		}
-		w, err := b.NewWriter(ctx, filepath.Join(base, info.Name()), nil)
+		w, err := b.NewWriter(ctx, strings.TrimPrefix(path, prefixDir), nil)
 		if err != nil {
 			log.Fatalf("Failed to obtain writer: %s", err)
 		}


### PR DESCRIPTION
This PR fixes some problems as follows

- fix `InvalidLocationConstraint` problem when upload files to s3 compatible storage，refer rook/rook#2446. Add an option to set region, backward compatible.
- fix the problem that adds an additional directory when uploading a single file, e.g. upload file db.txt -> db.txt/db.txt
- fix the problem that flattens all directories when upload nested directory
- Add an option to not generate a `.attrs` file for each downloaded file